### PR TITLE
Update to Zig 0.14

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -52,8 +52,8 @@ pub fn build(b: *Build) void {
     {
         const sdl = sdl_dep.artifact("SDL2");
         exe.linkLibrary(sdl);
-        const header_tree = sdl.installed_headers_include_tree orelse @panic("?");
-        exe.addIncludePath(header_tree.getDirectory().path(b, "SDL2"));
+        const header_tree = sdl.getEmittedIncludeTree();
+        exe.addIncludePath(header_tree.path(b, "SDL2"));
         exe.linkLibrary(addFAudio(b, target, optimize, sdl));
     }
     exe.linkLibrary(addTinyXml2(b, target, optimize));
@@ -69,7 +69,7 @@ pub fn build(b: *Build) void {
         const out_zip_file = run_zip.addOutputFileArg("data.zip");
         run_zip.addDirectoryArg(makeandplay_dep.path("."));
         b.getInstallStep().dependOn(
-            &b.addInstallBinFile(out_zip_file, "data.zip").step
+            &b.addInstallBinFile(out_zip_file, "data.zip").step,
         );
     }
 
@@ -108,7 +108,7 @@ fn addPhysfs(
         "src/physfs_platform_haiku.cpp",
         "src/physfs_platform_android.c",
     }) catch @panic("OOM");
-    if (target.result.isDarwin()) {
+    if (target.result.os.tag.isDarwin()) {
         files.append("src/physfs_platform_apple.m") catch @panic("OOM");
     }
     lib.addCSourceFiles(.{
@@ -122,7 +122,6 @@ fn addPhysfs(
     lib.linkLibCpp();
     return lib;
 }
-
 
 fn addTinyXml2(
     b: *Build,
@@ -195,7 +194,7 @@ fn addSheenBidi(
         .files = &.{
             "Source/SheenBidi.c",
         },
-        .flags = &.{ "-DSB_CONFIG_UNITY" },
+        .flags = &.{"-DSB_CONFIG_UNITY"},
     });
     lib.installHeadersDirectory(headers_path, ".", .{});
     lib.linkLibCpp();
@@ -281,7 +280,7 @@ fn addLodepng(
     return lib;
 }
 
-const src = [_][]const u8 {
+const src = [_][]const u8{
     "desktop_version/src/BinaryBlob.cpp",
     "desktop_version/src/BlockV.cpp",
     "desktop_version/src/ButtonGlyphs.cpp",
@@ -334,6 +333,6 @@ const src = [_][]const u8 {
     "desktop_version/src/Vlogging.c",
     "desktop_version/src/Xoshiro.c",
 };
-const physfs_src = [_][]const u8 {
+const physfs_src = [_][]const u8{
     "extras/physfsrwops.c",
 };

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,15 +1,16 @@
 .{
-    .name = "VVVVVV",
+    .name = .VVVVVV,
     .version = "0.0.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
+    .fingerprint = 0x34f87c4df8609942,
     .dependencies = .{
         .VVVVVV = .{
             .url = "https://github.com/TerryCavanagh/VVVVVV/archive/6df7d5df8af6787e3aee1f4df6639b5aa8e3884c.tar.gz",
             .hash = "12205a24de32aa7d0c9857320b6fb5d644b7c7af1d60dff4f5e0257881f9b0c98f3d",
         },
         .sdl = .{
-            .url = "git+https://github.com/allyourcodebase/SDL#7e4fc30b201d266f197fef4153f7e046bd189a7c",
-            .hash = "1220c57b0bec66a2378e90cd7a79e36f9e7f60c02acca769ab3e6f974d4ef6766418",
+            .url = "git+https://github.com/allyourcodebase/SDL#005c64130effb6019c42769d3a277180bdbeb0b2",
+            .hash = "SDL-2.32.6-JToi32yUEgFuZPcB2O6IbBHHsP2Ul8QuRYh488w2VnMy",
         },
         .physfs = .{
             .url = "https://github.com/icculus/physfs/archive/bfa7997c671957eb0a340ff1cf3c634e6269904a.tar.gz",
@@ -36,8 +37,8 @@
             .hash = "1220521ded1568db149ba4bd4e51aef847d31b760f402b6719137c1fa4b67d2c17e9",
         },
         .zipcmdline = .{
-            .url = "https://github.com/marler8997/zipcmdline/archive/436c68f8993a355f6ef0c65b43fd7d56d06bcedc.tar.gz",
-            .hash = "12203409341d97b9ed71926213814b88c3d3181ea944192278fc73357a2de6ca22dc",
+            .url = "git+https://github.com/marler8997/zipcmdline#376f65b28aa02a39f7277cd36a1b8d8f170704cc",
+            .hash = "zipcmdline-0.0.0-DFii0-FaAAAmtj5B70nXW43Ld27RctFfr7zO9EEg7tFG",
         },
         .makeandplay = .{
             .url = "https://thelettervsixtim.es/makeandplay/data.zip",


### PR DESCRIPTION
This PR should make VVVVVV compile with Zig 0.14. It was mostly updating the dependencies. There are also some small changes from the automatic formatter of my editor. Please let me know if I should remove these.